### PR TITLE
feat(hooks): 기준점과 플로팅 요소의 위치 값 계산을 위한 훅

### DIFF
--- a/src/shared/design-system/use-floating/index.ts
+++ b/src/shared/design-system/use-floating/index.ts
@@ -1,0 +1,1 @@
+export { default as useFloating } from "./use-floating"

--- a/src/shared/design-system/use-floating/position-calculators.ts
+++ b/src/shared/design-system/use-floating/position-calculators.ts
@@ -1,0 +1,31 @@
+/**
+ * @param targetStart - 기준점의 left, top, right, bottom
+ * @param targetSize  - 기준점의 width, height
+ * @param floatingSize - 플로팅 요소의 width, height
+ * @returns 기준점에 대한 가운데 정렬
+ */
+function centerAlign(targetStart: number, targetSize: number, floatingSize: number): number {
+  return targetStart + (targetSize - floatingSize) / 2
+}
+
+export const positionCalculators = {
+  top: (anchorRect: DOMRect, floatingRect: DOMRect, offset: number) => ({
+    top: anchorRect.top - floatingRect.height - offset,
+    left: centerAlign(anchorRect.left, anchorRect.width, floatingRect.width)
+  }),
+
+  bottom: (anchorRect: DOMRect, floatingRect: DOMRect, offset: number) => ({
+    top: anchorRect.bottom + offset,
+    left: centerAlign(anchorRect.left, anchorRect.width, floatingRect.width)
+  }),
+
+  left: (anchorRect: DOMRect, floatingRect: DOMRect, offset: number) => ({
+    left: anchorRect.left - floatingRect.width - offset,
+    top: centerAlign(anchorRect.top, anchorRect.height, floatingRect.height)
+  }),
+
+  right: (anchorRect: DOMRect, floatingRect: DOMRect, offset: number) => ({
+    left: anchorRect.right + offset,
+    top: centerAlign(anchorRect.top, anchorRect.height, floatingRect.height)
+  })
+}

--- a/src/shared/design-system/use-floating/use-floating.ts
+++ b/src/shared/design-system/use-floating/use-floating.ts
@@ -1,0 +1,98 @@
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react"
+
+import { useDebouncedCallback } from "../use-debounced-callback"
+
+import { positionCalculators } from "./position-calculators"
+
+import type { ComputedOffset, UseFloatingReturn, UsePositionParams } from "./use-floating.types"
+
+const DEBOUNCE_DELAY = 200
+
+export default function useFloating<TElement extends HTMLElement>({
+  offset = 0,
+  placement = "bottom"
+}: UsePositionParams = {}): UseFloatingReturn<TElement> {
+  const [computedOffset, setComputedOffset] = useState<ComputedOffset>({
+    position: "absolute",
+    top: "",
+    left: ""
+  })
+
+  const domReferenceRef = useRef<TElement>(null)
+  const floatingReferenceRef = useRef<TElement>(null)
+
+  const [isMounted, setIsMounted] = useState(false)
+
+  const setReference = useCallback((node: TElement | null) => {
+    domReferenceRef.current = node
+    setIsMounted(Boolean(node) && Boolean(floatingReferenceRef.current))
+  }, [])
+
+  const setFloatingReference = useCallback((node: TElement | null) => {
+    floatingReferenceRef.current = node
+    setIsMounted(Boolean(node) && Boolean(domReferenceRef.current))
+  }, [])
+
+  const updatePosition = useCallback(() => {
+    if (!domReferenceRef.current || !floatingReferenceRef.current) {
+      return
+    }
+
+    const position = calculateFloatingPosition(domReferenceRef.current, floatingReferenceRef.current, {
+      offset,
+      placement
+    })
+    setComputedOffset(position)
+  }, [offset, placement])
+
+  const debouncedUpdatePosition = useDebouncedCallback(updatePosition, DEBOUNCE_DELAY)
+
+  useLayoutEffect(() => {
+    if (!domReferenceRef.current || !floatingReferenceRef.current || !isMounted) {
+      return
+    }
+
+    debouncedUpdatePosition()
+
+    const resizeObserver = new ResizeObserver(debouncedUpdatePosition)
+    resizeObserver.observe(domReferenceRef.current!)
+    resizeObserver.observe(floatingReferenceRef.current!)
+    window.addEventListener("resize", debouncedUpdatePosition)
+
+    return () => {
+      resizeObserver.disconnect()
+      window.removeEventListener("resize", debouncedUpdatePosition)
+    }
+  }, [isMounted, debouncedUpdatePosition])
+
+  const refs = useMemo(
+    () => ({
+      domReferenceRef,
+      floatingReferenceRef,
+      setReference,
+      setFloatingReference,
+      computedOffset
+    }),
+    [setReference, setFloatingReference, computedOffset]
+  )
+
+  return refs
+}
+
+function calculateFloatingPosition<TElement extends HTMLElement>(
+  domReference: TElement,
+  floatingReference: TElement,
+  { offset = 0, placement = "bottom" }: UsePositionParams = {}
+): ComputedOffset {
+  const anchorRect = domReference.getBoundingClientRect()
+  const floatingRect = floatingReference.getBoundingClientRect()
+
+  const calculator = positionCalculators[placement]
+  const { top, left } = calculator(anchorRect, floatingRect, offset)
+
+  return {
+    position: "absolute",
+    top: `${top}px`,
+    left: `${left}px`
+  }
+}

--- a/src/shared/design-system/use-floating/use-floating.types.ts
+++ b/src/shared/design-system/use-floating/use-floating.types.ts
@@ -1,0 +1,22 @@
+import type { RefObject } from "react"
+
+export type Placement = "top" | "left" | "bottom" | "right"
+
+export interface UsePositionParams {
+  offset?: number
+  placement?: Placement
+}
+
+export interface UseFloatingReturn<TElement extends HTMLElement> {
+  domReferenceRef: RefObject<TElement | null>
+  floatingReferenceRef: RefObject<TElement | null>
+  setReference: (node: TElement | null) => void
+  setFloatingReference: (node: TElement | null) => void
+  computedOffset: ComputedOffset
+}
+
+export interface ComputedOffset {
+  position: "absolute"
+  top: string
+  left: string
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- closed #55 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- [x] 위치 계산 호출은 `useDebouncedCallback()`을 사용해 디바운싱 처리
- [x] `calculateFloatingPosition()`을 통해 위치(`top`, `left`) 계산
- [x] `ResizeObserver`와 `window.resize` 이벤트를 통해 위치 자동 갱신 

### 스크린샷 (선택)
