### PR TITLE
feat(textField): Input, Label을 추상화한 TextField 컴포넌트 구현

### DIFF
--- a/src/shared/design-system/text-field/text-field.stories.tsx
+++ b/src/shared/design-system/text-field/text-field.stories.tsx
@@ -1,0 +1,83 @@
+import TextField from "./text-field"
+
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+const meta: Meta<typeof TextField> = {
+  title: "Design System/TextField",
+  component: TextField,
+  tags: ["autodocs"]
+}
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    label: "Label",
+    as: "input",
+    error: false,
+    disabled: false,
+    placeholder: "Placeholder"
+  }
+}
+
+export const Textarea: Story = {
+  args: {
+    label: "Label",
+    as: "textarea",
+    error: false,
+    disabled: false,
+    placeholder: "Placeholder"
+  }
+}
+
+export const TextareaDisabled: Story = {
+  args: {
+    label: "Label",
+    as: "textarea",
+    error: false,
+    disabled: true,
+    placeholder: "Placeholder"
+  }
+}
+
+export const TextareaError: Story = {
+  args: {
+    label: "Label",
+    as: "textarea",
+    error: false,
+    disabled: true,
+    placeholder: "Placeholder"
+  }
+}
+
+export const Input: Story = {
+  args: {
+    label: "Label",
+    as: "input",
+    error: false,
+    disabled: false,
+    placeholder: "Placeholder"
+  }
+}
+
+export const InputError: Story = {
+  args: {
+    label: "Label",
+    as: "input",
+    error: true,
+    disabled: false,
+    placeholder: "Placeholder"
+  }
+}
+
+export const InputDisabled: Story = {
+  args: {
+    label: "Label",
+    as: "input",
+    error: false,
+    disabled: true,
+    placeholder: "Placeholder"
+  }
+}

--- a/src/shared/design-system/text-field/text-field.test.tsx
+++ b/src/shared/design-system/text-field/text-field.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import TextField from "./text-field"
+
+describe("TextField 렌더링 테스트", () => {
+  describe("기본 렌더링", () => {
+    it("기본 input 모드로 렌더링", () => {
+      render(<TextField />)
+
+      const input = screen.getByRole("textbox")
+      expect(input).toBeInTheDocument()
+      expect(input).toHaveValue("")
+      expect(input.tagName).toBe("INPUT")
+    })
+
+    it("textarea 모드로 렌더링", () => {
+      render(<TextField as="textarea" />)
+
+      const textarea = screen.getByRole("textbox")
+      expect(textarea).toBeInTheDocument()
+      expect(textarea.tagName).toBe("TEXTAREA")
+    })
+
+    it("label이 있을 때 렌더링", () => {
+      render(<TextField label="이름" id="name" />)
+
+      const label = screen.getByText("이름")
+      const input = screen.getByRole("textbox")
+
+      expect(label).toBeInTheDocument()
+      expect(label).toHaveAttribute("for", "name")
+      expect(input).toHaveAttribute("id", "name")
+    })
+
+    it("label이 없을 때 label 요소가 렌더링되지 않음", () => {
+      render(<TextField />)
+
+      const input = screen.getByRole("textbox")
+      expect(input).toBeInTheDocument()
+
+      expect(screen.queryByRole("label")).not.toBeInTheDocument()
+    })
+  })
+
+  describe("상태 관리", () => {
+    it("error 상태에서 에러 스타일 적용", () => {
+      render(<TextField error />)
+
+      const input = screen.getByRole("textbox")
+      expect(input).toHaveClass("border-error")
+    })
+
+    it("disabled 상태에서 비활성화", () => {
+      render(<TextField disabled />)
+
+      const input = screen.getByRole("textbox")
+      expect(input).toBeDisabled()
+    })
+
+    it("error와 disabled 상태 동시 적용", () => {
+      render(<TextField error disabled />)
+
+      const input = screen.getByRole("textbox")
+      expect(input).toHaveClass("border-error")
+      expect(input).toBeDisabled()
+    })
+  })
+
+  describe("사용자 인터랙션", () => {
+    it("input에서 텍스트 입력", async () => {
+      render(<TextField />)
+
+      const input = screen.getByRole("textbox")
+      await userEvent.type(input, "Hello World")
+
+      expect(input).toHaveValue("Hello World")
+    })
+
+    it("textarea에서 텍스트 입력", async () => {
+      render(<TextField as="textarea" />)
+
+      const textarea = screen.getByRole("textbox")
+      await userEvent.type(textarea, "Multi-line\ntext")
+
+      expect(textarea).toHaveValue("Multi-line\ntext")
+    })
+
+    it("disabled 상태에서 입력 불가", async () => {
+      render(<TextField disabled />)
+
+      const input = screen.getByRole("textbox")
+      await userEvent.type(input, "Hello")
+
+      expect(input).toHaveValue("")
+    })
+  })
+})

--- a/src/shared/design-system/text-field/text-field.tsx
+++ b/src/shared/design-system/text-field/text-field.tsx
@@ -1,10 +1,12 @@
+/* eslint-disable func-call-spacing */
+/* eslint-disable indent */
+import { forwardRef, type InputHTMLAttributes, type Ref, type TextareaHTMLAttributes } from "react"
+
 import { cn } from "@/shared/utils"
 
 import Input from "../input/input"
 import Label from "../label/label"
 import Textarea from "../textarea/textarea"
-
-import type { InputHTMLAttributes, TextareaHTMLAttributes } from "react"
 
 interface Props {
   label?: string
@@ -13,15 +15,10 @@ interface Props {
   disabled?: boolean
 }
 
-export default function TextField({
-  className,
-  id,
-  label,
-  as = "input",
-  error,
-  disabled,
-  ...restProps
-}: Props & (InputHTMLAttributes<HTMLInputElement> | TextareaHTMLAttributes<HTMLTextAreaElement>)) {
+const TextField = forwardRef<
+  HTMLInputElement | HTMLTextAreaElement,
+  Props & (InputHTMLAttributes<HTMLInputElement> | TextareaHTMLAttributes<HTMLTextAreaElement>)
+>(({ className, id, label, as = "input", error, disabled, ...restProps }, ref) => {
   return (
     <div className={cn(`flex flex-col gap-3`, className)}>
       {label && <Label htmlFor={id}>{label}</Label>}
@@ -31,6 +28,7 @@ export default function TextField({
           id={id}
           error={error}
           disabled={disabled}
+          ref={ref as Ref<HTMLInputElement>}
           {...(restProps as InputHTMLAttributes<HTMLInputElement>)}
         />
       )}
@@ -39,9 +37,14 @@ export default function TextField({
           id={id}
           error={error}
           disabled={disabled}
+          ref={ref as Ref<HTMLTextAreaElement>}
           {...(restProps as TextareaHTMLAttributes<HTMLTextAreaElement>)}
         />
       )}
     </div>
   )
-}
+})
+
+TextField.displayName = "TextField"
+
+export default TextField

--- a/src/shared/design-system/text-field/text-field.tsx
+++ b/src/shared/design-system/text-field/text-field.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable func-call-spacing */
-/* eslint-disable indent */
 import { forwardRef, type InputHTMLAttributes, type Ref, type TextareaHTMLAttributes } from "react"
 
 import { cn } from "@/shared/utils"
@@ -8,42 +6,43 @@ import Input from "../input/input"
 import Label from "../label/label"
 import Textarea from "../textarea/textarea"
 
-interface Props {
+interface BaseProps {
   label?: string
   as?: "input" | "textarea"
   error?: boolean
   disabled?: boolean
 }
 
-const TextField = forwardRef<
-  HTMLInputElement | HTMLTextAreaElement,
-  Props & (InputHTMLAttributes<HTMLInputElement> | TextareaHTMLAttributes<HTMLTextAreaElement>)
->(({ className, id, label, as = "input", error, disabled, ...restProps }, ref) => {
-  return (
-    <div className={cn(`flex flex-col gap-3`, className)}>
-      {label && <Label htmlFor={id}>{label}</Label>}
-      {as === "input" && (
-        <Input
-          type="text"
-          id={id}
-          error={error}
-          disabled={disabled}
-          ref={ref as Ref<HTMLInputElement>}
-          {...(restProps as InputHTMLAttributes<HTMLInputElement>)}
-        />
-      )}
-      {as === "textarea" && (
-        <Textarea
-          id={id}
-          error={error}
-          disabled={disabled}
-          ref={ref as Ref<HTMLTextAreaElement>}
-          {...(restProps as TextareaHTMLAttributes<HTMLTextAreaElement>)}
-        />
-      )}
-    </div>
-  )
-})
+type Props = BaseProps & (InputHTMLAttributes<HTMLInputElement> | TextareaHTMLAttributes<HTMLTextAreaElement>)
+
+const TextField = forwardRef<HTMLInputElement | HTMLTextAreaElement, Props>(
+  ({ className, id, label, as = "input", error, disabled, ...restProps }, ref) => {
+    return (
+      <div className={cn(`flex flex-col gap-3`, className)}>
+        {label && <Label htmlFor={id}>{label}</Label>}
+        {as === "input" && (
+          <Input
+            type="text"
+            id={id}
+            error={error}
+            disabled={disabled}
+            ref={ref as Ref<HTMLInputElement>}
+            {...(restProps as InputHTMLAttributes<HTMLInputElement>)}
+          />
+        )}
+        {as === "textarea" && (
+          <Textarea
+            id={id}
+            error={error}
+            disabled={disabled}
+            ref={ref as Ref<HTMLTextAreaElement>}
+            {...(restProps as TextareaHTMLAttributes<HTMLTextAreaElement>)}
+          />
+        )}
+      </div>
+    )
+  }
+)
 
 TextField.displayName = "TextField"
 

--- a/src/shared/design-system/text-field/text-field.tsx
+++ b/src/shared/design-system/text-field/text-field.tsx
@@ -1,0 +1,47 @@
+import { cn } from "@/shared/utils"
+
+import Input from "../input/input"
+import Label from "../label/label"
+import Textarea from "../textarea/textarea"
+
+import type { InputHTMLAttributes, TextareaHTMLAttributes } from "react"
+
+interface Props {
+  label?: string
+  as?: "input" | "textarea"
+  error?: boolean
+  disabled?: boolean
+}
+
+export default function TextField({
+  className,
+  id,
+  label,
+  as = "input",
+  error,
+  disabled,
+  ...restProps
+}: Props & (InputHTMLAttributes<HTMLInputElement> | TextareaHTMLAttributes<HTMLTextAreaElement>)) {
+  return (
+    <div className={cn(`flex flex-col gap-3`, className)}>
+      {label && <Label htmlFor={id}>{label}</Label>}
+      {as === "input" && (
+        <Input
+          type="text"
+          id={id}
+          error={error}
+          disabled={disabled}
+          {...(restProps as InputHTMLAttributes<HTMLInputElement>)}
+        />
+      )}
+      {as === "textarea" && (
+        <Textarea
+          id={id}
+          error={error}
+          disabled={disabled}
+          {...(restProps as TextareaHTMLAttributes<HTMLTextAreaElement>)}
+        />
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- #71 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

Label, Input을 따로 사용해도 문제 없을 수 있지만, 보통은 Label과 Input을 같이 사용하기 때문에 TextField 라는 네이밍으로 컴포넌트 추상화 작업 했습니다.

- 네이밍은 MUI 참고

[#71] 이슈 참조

### 스크린샷 (선택)
